### PR TITLE
chore: bump version to v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A set of [A-Frame](https://aframe.io) components for quickly creating rooms conn
 ```html
 <head>
   <script src="https://aframe.io/releases/1.7.1/aframe.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/gh/oparamo/aframe-room-component@v1.0.0/dist/aframe-room-component.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/oparamo/aframe-room-component@v2.0.0/dist/aframe-room-component.min.js"></script>
 </head>
 
 <body>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oparamo/aframe-room-component",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "An A-Frame component for quickly creating rooms connected by doors.",
   "main": "./dist/aframe-room-component.min.js",
   "module": "./dist/aframe-room-component.esm.js",


### PR DESCRIPTION
Manual version bump to v2.0.0. Code is already on master via PR #14; this PR updates package.json and the README CDN link to match.