### PR TITLE
fix: skip version-bump commit when package.json already at target version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           git config user.name "$BOT_NAME"
           git config user.email "$BOT_EMAIL"
           git add package.json README.md
-          git commit -m "chore: bump version to ${{ steps.get_version.outputs.new_tag }} [skip ci]"
+          git diff --staged --quiet || git commit -m "chore: bump version to ${{ steps.get_version.outputs.new_tag }} [skip ci]"
           git push
 
       - uses: mathieudutour/github-tag-action@v6.2


### PR DESCRIPTION
## Summary
- Adds `git diff --staged --quiet ||` guard before the `git commit` in the "Bump version references" step so the workflow doesn't fail with "nothing to commit" when `package.json` is already at the computed version.

## Why
The release workflow failed to publish v2.0.0 to npm due to an OIDC misconfiguration. After fixing OIDC, re-triggering the workflow failed at the commit step because `package.json` was already bumped to `2.0.0` by the previous run — leaving nothing to commit. This made `git commit` exit non-zero, aborting the workflow before the `pnpm publish` step.

Deleting the `v2.0.0` tag (already done) and merging this PR will cause the next CI run on master to re-trigger the release workflow, which will detect the major bump, skip the no-op commit, re-create the tag, and publish to npm.

## Test plan
- [x] Merge this PR
- [ ] Confirm CI passes on master
- [ ] Confirm the release workflow creates the `v2.0.0` tag and publishes `@oparamo/aframe-room-component@2.0.0` to npm