### PR TITLE
fix: use new_version output instead of bump_type for release conditions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
 
       # Bump package.json and README CDN link, commit, then create the tag
       - name: Bump version references
-        if: steps.get_version.outputs.bump_type != ''
+        if: steps.get_version.outputs.new_version != ''
         run: |
           npm version ${{ steps.get_version.outputs.new_version }} --no-git-tag-version
           sed -i "s|aframe-room-component@v[0-9]*\.[0-9]*\.[0-9]*|aframe-room-component@v${{ steps.get_version.outputs.new_version }}|g" README.md
@@ -57,13 +57,13 @@ jobs:
           git push
 
       - uses: mathieudutour/github-tag-action@v6.2
-        if: steps.get_version.outputs.bump_type != ''
+        if: steps.get_version.outputs.new_version != ''
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: ${{ steps.get_version.outputs.new_version }}
 
       - uses: actions/download-artifact@v8
-        if: steps.get_version.outputs.bump_type != ''
+        if: steps.get_version.outputs.new_version != ''
         with:
           name: dist
           path: dist/
@@ -71,19 +71,19 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - run: pnpm publish --no-git-checks --access public
-        if: steps.get_version.outputs.bump_type != ''
+        if: steps.get_version.outputs.new_version != ''
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - run: gh release create ${{ steps.get_version.outputs.new_tag }} --generate-notes dist/*
-        if: steps.get_version.outputs.bump_type != ''
+        if: steps.get_version.outputs.new_version != ''
         env:
           GH_TOKEN: ${{ github.token }}
 
   deploy-pages:
     name: Deploy demo
     needs: release
-    if: needs.release.outputs.bump_type != ''
+    if: needs.release.outputs.new_version != ''
     runs-on: ubuntu-latest
     permissions:
       actions: read


### PR DESCRIPTION
## Summary
- Replaces all `bump_type != ''` conditions with `new_version != ''` in the release job and deploy-pages job.

## Why
`github-tag-action@v6.2` does not emit `bump_type` when running in `dry_run: true` mode on Node 24 runners (the runner default as of mid-2026). The action correctly computes and logs the version bump — it sets `new_tag` and `new_version` — but `bump_type` remains unset. This caused every conditional step (version bump commit, tag creation, npm publish, GitHub release, Pages deploy) to be permanently skipped.

`new_version` is reliably emitted in dry_run mode and is an equivalent guard: it is only set when the action finds commits that warrant a bump.

## Test plan
- [ ] Merge this PR
- [ ] Confirm CI passes on master
- [ ] Confirm the release workflow picks up the major bump, creates the `v2.0.0` tag, and publishes `@oparamo/aframe-room-component@2.0.0` to npm